### PR TITLE
Openport 12388 internal port for the Kubernetes API Server

### DIFF
--- a/ops/playbooks/includes/internal_vars.yml
+++ b/ops/playbooks/includes/internal_vars.yml
@@ -31,7 +31,8 @@ internal_ucpk8s_ports:
   - 10250/tcp
   - 12376/tcp
   - 12378/tcp
-  - 12379-12387/tcp
+  - 12379-12386/tcp
+  - 12388/tcp
 
 internal_ucp200_ports:
   - 443/tcp


### PR DESCRIPTION
Open port 12388 on the UCP machines. This is to access the K8S API server. Was closed before