### PR TITLE
Fix windows code which opens port 1514 on the ansible box instead of …

### DIFF
--- a/ops/playbooks/splunk_uf.yml
+++ b/ops/playbooks/splunk_uf.yml
@@ -146,7 +146,6 @@
   hosts: logger win_worker
   gather_facts: false
   connection: local
-  user: remote
   become: false
 
   vars_files:
@@ -180,6 +179,8 @@
           immediate: true
           permanent: true
           state: enabled
+        delegate_to: "{{ groups.logger[0] }}"
+        become: true
         with_items: "{{ splunk_architecture_syslog_ports }}"
 
       when: inventory_hostname in groups.logger


### PR DESCRIPTION
vdi-1681: Fix windows code which used to open port 1514 on the ansible box instead of the logger VM

