### PR TITLE
VDI-1760 Download and install kubectl - set version  in vars file

### DIFF
--- a/group_vars/vars.sample
+++ b/group_vars/vars.sample
@@ -176,3 +176,7 @@ loadbalancers:
     public_fqdn: hpe-wrk.cloudra.local
     virtual_router_id: 53
 
+
+kubectl_version: "1.11.5"
+kubectl_checksum: "sha512:7028d357f65603398c35b7578793a153248e17c2ad631541a587f4ae13ef93f058db130390eea4820c2fd7707509ed0eb581cb129790b12680e869829a6fc241"
+

--- a/playbooks/install_kubectl.yml
+++ b/playbooks/install_kubectl.yml
@@ -1,0 +1,47 @@
+---
+- hosts: local
+  gather_facts: false
+  become_user: root
+  become: true
+
+  vars:
+    kubectl_tmp_directory: "{{lookup('env', 'TMPDIR') | default('/tmp',true)}}"
+    kubectl_os: "linux"
+    kubectl_arch: "amd64"
+    kubectl_bin_directory: "/usr/local/bin"
+    kubectl_owner: "root"
+    kubectl_group: "root"
+
+
+  environment: "{{ env }}"
+
+  tasks:
+
+    - name: Download kubernetes-client archive
+      get_url:
+        url: "https://dl.k8s.io/v{{kubectl_version}}/kubernetes-client-{{kubectl_os}}-{{kubectl_arch}}.tar.gz"
+        checksum: "{{kubectl_checksum}}"
+        dest: "{{kubectl_tmp_directory}}"
+      tags:
+        - kubectl
+
+    - name: Unarchive kubernetes-client
+      unarchive:
+        src: "{{kubectl_tmp_directory}}/kubernetes-client-{{kubectl_os}}-{{kubectl_arch}}.tar.gz"
+        dest: "{{kubectl_tmp_directory}}"
+      tags:
+        - kubectl
+
+    - name: Copy kubectl binary to destination directory
+      copy:
+        src: "{{kubectl_tmp_directory}}/kubernetes/client/bin/{{item}}"
+        dest: "{{kubectl_bin_directory}}/{{item}}"
+        mode: 0755
+        owner: root
+        group: root
+        remote_src: yes
+      with_items:
+        - kubectl
+
+
+

--- a/playbooks/install_kubectl.yml
+++ b/playbooks/install_kubectl.yml
@@ -4,6 +4,9 @@
   become_user: root
   become: true
 
+  vars_files:
+  - ../group_vars/vars
+
   vars:
     kubectl_tmp_directory: "{{lookup('env', 'TMPDIR') | default('/tmp',true)}}"
     kubectl_os: "linux"


### PR DESCRIPTION
playbook to install kubectl - precursor for another standalone playbook to install the client bundle and then allow kubectl command to be used in other playbooks

requires version and checksum to be set in vars file - other, more specific variables are left in playbook, but could be moved to vars if required

based on https://github.com/githubixx/ansible-role-kubectl 

