### PR TITLE
VDI-1762 standalone playbook to download client bundle and test kubec…

### DIFF
--- a/playbooks/install_client_bundle.yml
+++ b/playbooks/install_client_bundle.yml
@@ -1,0 +1,75 @@
+---
+- hosts: local
+  gather_facts: false
+  become_user: root
+  become: true
+  vars_files:
+  - ../group_vars/vars
+  - ../group_vars/vault
+
+  tasks:
+
+  - include_tasks: includes/find_ucp.yml
+    vars:
+      ping_servers: "{{ groups.ucp }}"
+  - debug: var=ucp_instance
+    when: _debug is defined
+
+
+#
+# Retrieve and remember a Token for using the UCP API
+#
+  - name: Retrieve a token for the UCP API
+    uri:
+      url: "https://{{ ucp_instance }}.{{ domain_name }}/auth/login"
+      headers:
+        Content-Type: application/json
+      method: POST
+      status_code: 200
+      body_format: json
+      validate_certs: no
+      body: '{"username":"{{ ucp_username }}","password":"{{ ucp_password }}"}'
+      use_proxy: no
+    register: login
+    until: login.status == 200
+    retries: 20
+    delay: 5
+
+  - name: Remember the token
+    set_fact:
+      auth_token:  "{{ login.json.auth_token }}"
+
+  - name: Get the client bundle
+    get_url:
+      url: 'https://{{ ucp_instance }}.{{ domain_name }}/api/clientbundle'
+      headers: 'Authorization: Bearer {{ auth_token }}'
+      validate_certs: no
+      force: yes
+      dest: /tmp/bundle.zip
+    register: resp
+
+
+  - name: Creates directory
+    file: path=~/certs.{{ ucp_instance }}.{{ ucp_username }} state=directory
+    register: file_details
+
+  - set_fact:
+      actual_path: "{{ file_details.path }}"
+
+  - name: unarchive the client bundle
+    unarchive:
+      src: /tmp/bundle.zip
+      dest: "{{ actual_path  }}"
+
+
+  - name: Test client
+    shell: |
+      . env.sh
+      kubectl version
+    args:
+      chdir: ~/certs.{{ ucp_instance }}.{{ ucp_username }}
+      executable: /usr/bin/bash
+    register: ps
+
+  - debug: var=ps.stdout_lines
+


### PR DESCRIPTION
Standalone playbook to download client bundle and test kubectl access

Stores bundle in  ~/certs.{{ ucp_instance }}.{{ ucp_username }}  to make it easier to maintain certs for multiple deployments

Assumes kubectl is already installed - prints out cluster details and the output from "kubectl version" - should show both client and server version if access is working correctly

Based on includes/config_client.yml  but does not include it explicitly as changes may not be compatible - can be refactored later to re-use include file

After running this playbook, you will still need to explicitly setup the env (for example)  

cd ~/certs.hpe2-ucp01.admin/
eval "$(<env.sh)" 

to get the environment variables set up locally in your terminal

