### PR TITLE
VDI-1723 - use updated sysdig configmap and daemonset for k83 1.11

### DIFF
--- a/group_vars/vars.sample
+++ b/group_vars/vars.sample
@@ -135,6 +135,8 @@ monitoring_stack: splunk_demo
 #
 # Sysdig
 #
+sysdig_collector: 'collector.sysdigcloud.com'
+sysdig_collector_port: '6666'
 sysdig_agent: 'https://s3.amazonaws.com/download.draios.com/stable/install-agent'
 sysdig_tags: 'location:EnterCity,role:Enterprise CaaS on Synergy,owner:Customer name'
 

--- a/playbooks/sysdig-k8s-rbac.yml
+++ b/playbooks/sysdig-k8s-rbac.yml
@@ -1,0 +1,136 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+---
+- name: Install sysdig
+  hosts: docker
+  vars_files:
+    - ../group_vars/vars
+    - ../group_vars/vault
+
+  environment: "{{ env }}"
+  tasks:
+    #
+    # Open required firewall ports
+    #
+    - name: Configure required firewall ports
+      firewalld:
+        port: "{{ sysdig_collector_port }}/tcp"
+        permanent: true
+        immediate: true
+        state: enabled
+
+    # Verify remote system can open a connection to
+    # collector.sysdigcloud.com port to send Sysdig
+    # information to Sysdig's SaaS instance.  If the connection
+    # succeeds then set the variable 'sysdig_connection'
+    # to 'true' and continue.  Otherwise print an error
+    # message explaining that connectivity requirements
+    # were not met.
+
+    - name: Check connectivity to collector.sysdigcloud.com port 
+      wait_for:
+        host: "{{ sysdig_collector }}"
+        port: "{{ sysdig_collector_port }}"
+        state: started
+        timeout: 10
+        msg: "Connectivity to {{ sysdig_collector }} port {{ sysdig_collector_port }} failed!  Exiting."
+
+    - set_fact:
+        sysdig_connection: true
+
+    - name: Install Kernel Headers
+      yum:
+        name: kernel-devel-{{ ansible_kernel }}
+        state: latest
+        update_cache: yes
+
+
+
+
+
+
+- hosts: local
+  connection: local
+  gather_facts: false
+
+  vars_files:
+    - ../group_vars/vars
+    - ../group_vars/vault
+
+  tasks:
+
+
+    - name: Copy sysdig namespace template
+      template:
+        src: ../templates/sysdig/k8s/sysdig-namespace.yml.j2
+        dest: /tmp/sysdig-namespace.yml
+
+    - name: Copy sysdig serviceaccount template
+      template:
+        src: ../templates/sysdig/k8s/sysdig-serviceaccount.yml.j2
+        dest: /tmp/sysdig-serviceaccount.yml
+
+    - name: Copy sysdig clusterrole template
+      template:
+        src: ../templates/sysdig/k8s/sysdig-agent-clusterrole.yml.j2
+        dest: /tmp/sysdig-agent-clusterrole.yml
+
+    - name: Copy sysdig clusterrolebinding template
+      template:
+        src: ../templates/sysdig/k8s/sysdig-clusterrolebinding.yml.j2
+        dest: /tmp/sysdig-clusterrolebinding.yml
+
+    - name: Copy sysdig daemonset template
+      template:
+        src: ../templates/sysdig/k8s/sysdig-agent-daemonset-v1.yml.j2
+        dest: /tmp/sysdig-agent-daemonset-v1.yml
+
+    - name: Copy sysdig daemonset template v2
+      template:
+        src: ../templates/sysdig/k8s/sysdig-agent-daemonset-v2.yml.j2
+        dest: /tmp/sysdig-agent-daemonset-v2.yml
+
+
+    - name: Copy sysdig configmap template v2
+      template:
+        src: ../templates/sysdig/k8s/sysdig-agent-configmap.yml.j2
+        dest: /tmp/sysdig-agent-configmap.yml
+
+
+    - include_tasks: includes/find_ucp.yml
+      vars:
+        ping_servers: "{{ groups.ucp }}"
+    - debug: var=ucp_instance
+      when: _debug is defined
+
+    # Assume playbooks/install_client_bundle.yml has been run before this 
+    # Assume that ucp_instance hasn't changed in the meantime
+    # - include_tasks: includes/config_client.yml
+
+    - name: Apply yml files to install agent
+      shell: |
+        . env.sh
+        kubectl apply -f /tmp/sysdig-namespace.yml
+        kubectl apply -f /tmp/sysdig-serviceaccount.yml
+        kubectl apply -f /tmp/sysdig-agent-clusterrole.yml
+        kubectl apply -f /tmp/sysdig-clusterrolebinding.yml
+        # kubectl -n sysdig apply -f /tmp/sysdig-agent-daemonset-v1.yml --validate=false
+        kubectl -n sysdig create secret generic sysdig-agent --from-literal=access-key={{ sysdig_access_key }}
+        kubectl -n sysdig apply -f /tmp/sysdig-agent-daemonset-v2.yml
+      args:
+        chdir: ~/certs.{{ ucp_instance }}.{{ ucp_username }}
+        executable: /usr/bin/bash
+      register: ps
+
+    - debug: var=ps.stdout_lines
+

--- a/templates/sysdig/k8s/deploy-sysdig.yml.j2
+++ b/templates/sysdig/k8s/deploy-sysdig.yml.j2
@@ -1,0 +1,105 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: sysdig-agent
+  labels:
+    app: sysdig-agent
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: sysdig-agent
+    spec:
+      volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+      - name: docker-sock
+        hostPath:
+          path: /var/run/docker.sock
+      - name: dev-vol
+        hostPath:
+          path: /dev
+      - name: proc-vol
+        hostPath:
+          path: /proc
+      - name: boot-vol
+        hostPath:
+          path: /boot
+      - name: modules-vol
+        hostPath:
+          path: /lib/modules
+      - name: usr-vol
+        hostPath:
+          path: /usr
+      hostNetwork: true
+      hostPID: true
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+      ### OPTIONAL: If using OpenShift or Kubernetes RBAC you need to uncomment the following line
+      serviceAccount: sysdig
+      containers:
+      - name: sysdig-agent
+        image: sysdig/agent
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          # Resources needed are subjective on the actual workload
+          # please refer to Sysdig Support for more info about it
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            memory: 1024Mi
+        readinessProbe:
+          exec:
+            command: [ "test", "-e", "/opt/draios/logs/draios.log" ]
+          initialDelaySeconds: 10
+        env:
+        ### REQUIRED: replace with your Sysdig Platform access key
+        - name: ACCESS_KEY
+          value: '{{ sysdig_access_key }}'
+        ### OPTIONAL: add tags for this host
+        # - name: TAGS
+        #   value: linux:ubuntu,dept:dev,local:nyc
+        ### OPTIONAL: Needed to connect to a Sysdig On-Premises backend
+        # - name: COLLECTOR
+        #   value: collector-staging.sysdigcloud.com
+        # - name: COLLECTOR_PORT
+        #   value: "6443"
+        # - name: COLLECTOR
+        #   value: 192.168.183.200
+        # - name: SECURE
+        #   value: "true"
+        # - name: CHECK_CERTIFICATE
+        #   value: "false"
+        ### OPTIONAL: Add additional parameters to the agent, refer to our Docs to know all options available
+        - name: ADDITIONAL_CONF
+          value: |
+          new_k8s: true
+          k8s_cluster_name: 'gabriels_cluster' 
+        volumeMounts:
+        - mountPath: /host/var/run/docker.sock
+          name: docker-sock
+          readOnly: false
+        - mountPath: /host/dev
+          name: dev-vol
+          readOnly: false
+        - mountPath: /host/proc
+          name: proc-vol
+          readOnly: true
+        - mountPath: /host/boot
+          name: boot-vol
+          readOnly: true
+        - mountPath: /host/lib/modules
+          name: modules-vol
+          readOnly: true
+        - mountPath: /host/usr
+          name: usr-vol
+          readOnly: true
+        - mountPath: /dev/shm
+          name: dshm

--- a/templates/sysdig/k8s/sysdig-agent-clusterrole.yml.j2
+++ b/templates/sysdig/k8s/sysdig-agent-clusterrole.yml.j2
@@ -1,0 +1,59 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sysdig-agent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - replicationcontrollers
+  - services
+  - events
+  - limitranges
+  - namespaces
+  - nodes
+  - resourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  - ingresses
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch

--- a/templates/sysdig/k8s/sysdig-agent-configmap.yml.j2
+++ b/templates/sysdig/k8s/sysdig-agent-configmap.yml.j2
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sysdig-agent
+data:
+  dragent.yaml: |
+    ### Agent tags
+    # tags: linux:ubuntu,dept:dev,local:nyc
+
+    #### Sysdig Software related config ####
+
+    # Sysdig collector address
+    collector: '{{ sysdig_collector }}'
+
+    # Collector TCP port
+    collector_port: '{{ sysdig_collector_port }}'
+
+    # Whether collector accepts ssl
+    ssl: true
+
+    # collector certificate validation
+    # ssl_verify_certificate: true
+
+    #######################################
+    new_k8s: true
+    k8s_cluster_name: '{{ k8s_cluster }}'

--- a/templates/sysdig/k8s/sysdig-agent-daemonset-v1.yml.j2
+++ b/templates/sysdig/k8s/sysdig-agent-daemonset-v1.yml.j2
@@ -1,0 +1,117 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: sysdig-agent
+  labels:
+    app: sysdig-agent
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: sysdig-agent
+    spec:
+      volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+      - name: dev-vol
+        hostPath:
+          path: /dev
+      - name: proc-vol
+        hostPath:
+          path: /proc
+      - name: boot-vol
+        hostPath:
+          path: /boot
+      - name: modules-vol
+        hostPath:
+          path: /lib/modules
+      - name: usr-vol
+        hostPath:
+          path: /usr
+      - name: run-vol
+        hostPath:
+          path: /run
+      - name: varrun-vol
+        hostPath:
+          path: /var/run
+      hostNetwork: true
+      hostPID: true
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+      ### OPTIONAL: If using OpenShift or Kubernetes RBAC you need to uncomment the following line
+      serviceAccount: sysdig
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: sysdig-agent
+        image: sysdig/agent
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          # Resources needed are subjective on the actual workload
+          # please refer to Sysdig Support for more info about it
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            memory: 1024Mi
+        readinessProbe:
+          exec:
+            command: [ "test", "-e", "/opt/draios/logs/running" ]
+          initialDelaySeconds: 10
+        env:
+        ### REQUIRED: replace with your Sysdig Platform access key
+        - name: ACCESS_KEY
+          value: '{{ sysdig_access_key }}'
+        ### OPTIONAL: add tags for this host
+        # - name: TAGS
+        #   value: linux:ubuntu,dept:dev,local:nyc
+        ### OPTIONAL: Needed to connect to a Sysdig On-Premises backend
+        # - name: COLLECTOR
+        #   value: collector-staging.sysdigcloud.com
+        # - name: COLLECTOR_PORT
+        #   value: "6443"
+        # - name: COLLECTOR
+        #   value: 192.168.183.200
+        # - name: SECURE
+        #   value: "true"
+        # - name: CHECK_CERTIFICATE
+        #   value: "false"
+        ### OPTIONAL: Add additional parameters to the agent, refer to our Docs to know all options available
+        #- name: COLLECTOR
+        #  value: collector.sysdigcloud.com
+        #- name: COLLECTOR_PORT
+        #  value: '{{ sysdig_collector_port }}'
+        #- name: SECURE
+        #  value: "false"
+
+        - name: ADDITIONAL_CONF
+          value: |
+            new_k8s: true
+            k8s_cluster_name: '{{ k8s_cluster }}'
+        volumeMounts:
+        - mountPath: /host/dev
+          name: dev-vol
+          readOnly: false
+        - mountPath: /host/proc
+          name: proc-vol
+          readOnly: true
+        - mountPath: /host/boot
+          name: boot-vol
+          readOnly: true
+        - mountPath: /host/lib/modules
+          name: modules-vol
+          readOnly: true
+        - mountPath: /host/usr
+          name: usr-vol
+          readOnly: true
+        - mountPath: /host/run
+          name: run-vol
+        - mountPath: /host/var/run
+          name: varrun-vol
+        - mountPath: /dev/shm
+          name: dshm

--- a/templates/sysdig/k8s/sysdig-agent-daemonset-v2.yml.j2
+++ b/templates/sysdig/k8s/sysdig-agent-daemonset-v2.yml.j2
@@ -1,0 +1,99 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: sysdig-agent
+  labels:
+    app: sysdig-agent
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: sysdig-agent
+    spec:
+      volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+      - name: dev-vol
+        hostPath:
+          path: /dev
+      - name: proc-vol
+        hostPath:
+          path: /proc
+      - name: boot-vol
+        hostPath:
+          path: /boot
+      - name: modules-vol
+        hostPath:
+          path: /lib/modules
+      - name: usr-vol
+        hostPath:
+          path: /usr
+      - name: run-vol
+        hostPath:
+          path: /run
+      - name: varrun-vol
+        hostPath:
+          path: /var/run
+      - name: sysdig-agent-config
+        configMap:
+          name: sysdig-agent
+          optional: true
+      - name: sysdig-agent-secrets
+        secret:
+          secretName: sysdig-agent
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      hostPID: true
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+      ### OPTIONAL: If using OpenShift or Kubernetes RBAC you need to uncomment the following line
+      serviceAccount: sysdig
+      terminationGracePeriodSeconds: 5
+      containers:
+      - name: sysdig-agent
+        image: sysdig/agent
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        resources:
+          # Resources needed are subjective on the actual workload
+          # please refer to Sysdig Support for more info about it
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            memory: 1024Mi
+        readinessProbe:
+          exec:
+            command: [ "test", "-e", "/opt/draios/logs/running" ]
+          initialDelaySeconds: 10
+        volumeMounts:
+        - mountPath: /host/dev
+          name: dev-vol
+          readOnly: false
+        - mountPath: /host/proc
+          name: proc-vol
+          readOnly: true
+        - mountPath: /host/boot
+          name: boot-vol
+          readOnly: true
+        - mountPath: /host/lib/modules
+          name: modules-vol
+          readOnly: true
+        - mountPath: /host/usr
+          name: usr-vol
+          readOnly: true
+        - mountPath: /host/run
+          name: run-vol
+        - mountPath: /host/var/run
+          name: varrun-vol
+        - mountPath: /dev/shm
+          name: dshm
+        - mountPath: /opt/draios/etc/kubernetes/config
+          name: sysdig-agent-config
+        - mountPath: /opt/draios/etc/kubernetes/secrets
+          name: sysdig-agent-secrets

--- a/templates/sysdig/k8s/sysdig-clusterrolebinding.yml.j2
+++ b/templates/sysdig/k8s/sysdig-clusterrolebinding.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sysdig-sysdig:sysdig-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sysdig-agent
+subjects:
+- kind: ServiceAccount
+  name: sysdig
+  namespace: sysdig

--- a/templates/sysdig/k8s/sysdig-namespace.yml.j2
+++ b/templates/sysdig/k8s/sysdig-namespace.yml.j2
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sysdig

--- a/templates/sysdig/k8s/sysdig-serviceaccount.yml.j2
+++ b/templates/sysdig/k8s/sysdig-serviceaccount.yml.j2
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sysdig
+  namespace: sysdig


### PR DESCRIPTION
Creates namespace, serviceaccount, clusterrole, clusterrolebinding, secret, daemonset + configmap to install sysdig agent for k8s 1.11 and Docker 2.1

Assumes that kubectl has been installed and that the client bundle lives in  ~/certs.{{ ucp_instance }}.{{ ucp_username }}

(i.e. first run playbooks/install_kubectl.yml and playbooks/install_client_bundle.yml)