### PR TITLE
VDI-1783 - deploy nfs-provisioner with RBAC and test persistent volum…

### DIFF
--- a/group_vars/vars.sample
+++ b/group_vars/vars.sample
@@ -145,14 +145,17 @@ sysdig_restricted_control_role: 'Restricted Control'
 k8s_cluster: 'ucp_hpe-ucp.cloudra.local'
 
 #k8s nfs provisionner role name
+nfs_provisioner_namespace: nfsstorage
+nfs_provisioner_serviceaccount: 'nfs-provisioner'
 nfs_provisioner_role: 'nfs-provisioner-runner'
 nfs_provisioner_name: "hpe.com/nfs"
 nfs_provisioner_storage_class_name: "nfs"
-nfs_provisioner_namespace: nfsstorage
+nfs_provisioner_server_ip: hpe-nfs.cloudra.local
+nfs_provisioner_server_share: '/k8s'
+
+
 #nfs_provisioner_server_ip: vfs3par.cloudra.local
 #nfs_provisioner_server_share: '/vfs3par/vfs3par/fs_clh/share'
-nfs_provisioner_server_ip: clh-nfs.cloudra.local
-nfs_provisioner_server_share: '/k8s'
 
 
 #storage driver for docker nodes: accepted values are 'overlay2' and devicemapper

--- a/playbooks/nfs-provisioner.yml
+++ b/playbooks/nfs-provisioner.yml
@@ -1,0 +1,116 @@
+###
+# Copyright (2017) Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###
+---
+- name: Install NFS provisioner
+  hosts: local
+  connection: local
+  gather_facts: false
+
+  vars_files:
+    - ../group_vars/vars
+    - ../group_vars/vault
+
+  environment: "{{ env }}"
+
+  tasks:
+
+    - debug: msg="Starting Playbook nfs-provisioner"
+
+    - name: Copy nfs-provisioner namespace template
+      template:
+        src: ../templates/nfs-provisioner/nfs-provisioner-namespace.yml.j2
+        dest: /tmp/nfs-provisioner-namespace.yml
+
+
+    - name: Copy nfs-provisioner rbac  template
+      template:
+        src: ../templates/nfs-provisioner/nfs-provisioner-rbac.yml.j2
+        dest: /tmp/nfs-provisioner-rbac.yml
+
+
+
+    - name: Copy nfs-provisioner deployment template
+      template:
+        src: ../templates/nfs-provisioner/nfs-provisioner-deployment.yml.j2
+        dest: /tmp/nfs-provisioner-deployment.yml
+
+    - name: Copy nfs-provisioner storageclass  template
+      template:
+        src: ../templates/nfs-provisioner/nfs-provisioner-storageclass.yml.j2
+        dest: /tmp/nfs-provisioner-storageclass.yml
+
+
+
+    - include_tasks: includes/find_ucp.yml
+      vars:
+        ping_servers: "{{ groups.ucp }}"
+    - debug: var=ucp_instance
+      when: _debug is defined
+
+
+    # Assume playbooks/install_client_bundle.yml has been run before this
+    # Assume that ucp_instance hasn't changed in the meantime
+    # - include_tasks: includes/config_client.yml
+
+    - name: Apply yml files to install nfs provisioner
+      shell: |
+        . env.sh
+        kubectl apply -f /tmp/nfs-provisioner-namespace.yml
+        kubectl -n {{ nfs_provisioner_namespace }} apply -f /tmp/nfs-provisioner-rbac.yml
+        kubectl -n {{ nfs_provisioner_namespace }} apply -f /tmp/nfs-provisioner-deployment.yml
+        kubectl -n {{ nfs_provisioner_namespace }} apply -f /tmp/nfs-provisioner-storageclass.yml
+      args:
+        chdir: ~/certs.{{ ucp_instance }}.{{ ucp_username }}
+        executable: /usr/bin/bash
+      register: ps
+
+    - debug: var=ps.stdout_lines
+
+
+
+    - name: Copy nfs-provisioner test-claim template
+      template:
+        src: ../templates/nfs-provisioner/nfs-provisioner-test-claim.yml.j2
+        dest: /tmp/nfs-provisioner-test-claim.yml
+
+    - name: Copy nfs-provisioner test-pod  template
+      template:
+        src: ../templates/nfs-provisioner/nfs-provisioner-test-pod.yml.j2
+        dest: /tmp/nfs-provisioner-test-pod.yml
+
+
+
+    - name: Test nfs provisioner
+      shell: |
+        . env.sh
+        kubectl -n {{ nfs_provisioner_namespace }} apply -f /tmp/nfs-provisioner-test-claim.yml
+        kubectl -n {{ nfs_provisioner_namespace }} apply -f /tmp/nfs-provisioner-test-pod.yml
+        sleep 5 # need sleep here to allow pod/container to start up and write file
+        ssh {{ nfs_provisioner_server_ip }} ls -R {{ nfs_provisioner_server_share }}
+        echo '*** delete test-pod ***'
+        kubectl -n {{ nfs_provisioner_namespace }} delete -f /tmp/nfs-provisioner-test-pod.yml
+        echo '*** cat bar.txt ***'
+        ssh {{ nfs_provisioner_server_ip }} "cd {{ nfs_provisioner_server_share }}/{{nfs_provisioner_namespace }}*; cat bar.txt"
+        echo '*** delete test-claim ***'
+        kubectl -n {{ nfs_provisioner_namespace }} delete -f /tmp/nfs-provisioner-test-claim.yml
+      args:
+        chdir: ~/certs.{{ ucp_instance }}.{{ ucp_username }}
+        executable: /usr/bin/bash
+      register: ps
+
+    - debug: var=ps.stdout_lines
+
+

--- a/templates/nfs-provisioner/nfs-provisioner-deployment.yml.j2
+++ b/templates/nfs-provisioner/nfs-provisioner-deployment.yml.j2
@@ -1,0 +1,35 @@
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: nfs-client-provisioner
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: nfs-client-provisioner
+    spec:
+#      nodeSelector:
+#        kubernetes.io/hostname: "{{ groups.ucp[0] }}.{{ domain_name }}"
+#        node-role.kubernetes.io/master: ""
+      serviceAccountName: {{ nfs_provisioner_serviceaccount }}
+      containers:
+        - name: nfs-client-provisioner
+          image: quay.io/external_storage/nfs-client-provisioner:latest
+          volumeMounts:
+            - name: nfs-client-root
+              mountPath: /persistentvolumes
+          env:
+            - name: PROVISIONER_NAME
+              value: '{{ nfs_provisioner_name }}'
+            - name: NFS_SERVER
+              value: '{{ nfs_provisioner_server_ip }}'
+            - name: NFS_PATH
+              value: '{{ nfs_provisioner_server_share }}'
+      volumes:
+        - name: nfs-client-root
+          nfs:
+            server: '{{ nfs_provisioner_server_ip }}'
+            path: '{{ nfs_provisioner_server_share }}'

--- a/templates/nfs-provisioner/nfs-provisioner-namespace.yml.j2
+++ b/templates/nfs-provisioner/nfs-provisioner-namespace.yml.j2
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ nfs_provisioner_namespace }}

--- a/templates/nfs-provisioner/nfs-provisioner-rbac.yml.j2
+++ b/templates/nfs-provisioner/nfs-provisioner-rbac.yml.j2
@@ -1,0 +1,57 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ nfs_provisioner_serviceaccount }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ nfs_provisioner_role }}
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ nfs_provisioner_namespace }}-{{ nfs_provisioner_serviceaccount }}:{{ nfs_provisioner_role }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ nfs_provisioner_serviceaccount }}
+    namespace: {{ nfs_provisioner_namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ nfs_provisioner_role }}
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: leader-locking-nfs-client-provisioner
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: leader-locking-nfs-client-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: {{ nfs_provisioner_serviceaccount }}
+    namespace: {{ nfs_provisioner_namespace }}
+roleRef:
+  kind: Role
+  name: leader-locking-nfs-client-provisioner
+  apiGroup: rbac.authorization.k8s.io

--- a/templates/nfs-provisioner/nfs-provisioner-storageclass.yml.j2
+++ b/templates/nfs-provisioner/nfs-provisioner-storageclass.yml.j2
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: '{{ nfs_provisioner_storage_class_name }}'
+provisioner: '{{ nfs_provisioner_name }}' 
+parameters:
+  archiveOnDelete: "false"

--- a/templates/nfs-provisioner/nfs-provisioner-test-claim.yml.j2
+++ b/templates/nfs-provisioner/nfs-provisioner-test-claim.yml.j2
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: test-claim
+  annotations:
+    volume.beta.kubernetes.io/storage-class: '{{ nfs_provisioner_storage_class_name }}'
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Mi

--- a/templates/nfs-provisioner/nfs-provisioner-test-pod.yml.j2
+++ b/templates/nfs-provisioner/nfs-provisioner-test-pod.yml.j2
@@ -1,0 +1,21 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: test-pod
+    image: gcr.io/google_containers/busybox:1.24
+    command:
+      - "/bin/sh"
+    args:
+      - "-c"
+      - "echo hello >/mnt/bar.txt  && exit 0 || exit 1"
+    volumeMounts:
+      - name: nfs-pvc
+        mountPath: "/mnt"
+  restartPolicy: "Never"
+  volumes:
+    - name: nfs-pvc
+      persistentVolumeClaim:
+        claimName: test-claim


### PR DESCRIPTION
Uses clusterrolebinding for RBAC

Includes test to create persistent volume claim and use it from a pod

Test pod writes file to pvc: 

  containers:
  - name: test-pod
    image: gcr.io/google_containers/busybox:1.24
    command:
      - "/bin/sh"
    args:
      - "-c"
      - "echo hello >/mnt/bar.txt  && exit 0 || exit 1"
    volumeMounts:
      - name: nfs-pvc
        mountPath: "/mnt"


Output shows file "bar.txt" surviving after pod is deleted:



        "persistentvolumeclaim/test-claim created",
        "pod/test-pod created",

        "/k8s:",
        "nfsstorage-test-claim-pvc-af5835fc-1f40-11e9-adf3-0242ac110003",
        "",
        "/k8s/nfsstorage-test-claim-pvc-af5835fc-1f40-11e9-adf3-0242ac110003:",
        "bar.txt",


        "*** delete test-pod ***",
        "pod \"test-pod\" deleted",

        "*** cat bar.txt ***",
        "hello",


        "*** delete test-claim ***",
        "persistentvolumeclaim \"test-claim\" deleted"


Maybe, separate out basic test into separate unit test playbook in future...
