### PR TITLE
DTR VDI-1806 backup and restore new DTR version fix

### DIFF
--- a/group_vars/vars.sample
+++ b/group_vars/vars.sample
@@ -48,8 +48,8 @@ env:
 # Docker configuration
 docker_ee_reponame: 'stable-18.09'
 rhel_version: '7'
-dtr_version: '2.6.2'
-ucp_version: '3.1.3'
+dtr_version: '2.6.4'
+ucp_version: '3.1.4'
 images_folder: '/docker-images'
 license_file: '/root/license.lic'
 ucp_username: 'admin'


### PR DESCRIPTION
Updated vars.sample to have UCP version 3.1.4 and DTR version 2.6.4 which bring through DTR repository fix.